### PR TITLE
reading and setting goal current

### DIFF
--- a/src/dynamixel/DynamixelDevice.js
+++ b/src/dynamixel/DynamixelDevice.js
@@ -282,6 +282,23 @@ export class DynamixelDevice extends EventEmitter {
   }
 
   /**
+   * Set goal current 
+   * @param {number} current - Goal current (0-max mA)
+   * @returns {Promise<boolean>} - Success status
+   */
+  async setGoalCurrent(current) {
+    return await this.writeWord(CONTROL_TABLE.GOAL_CURRENT, current);
+  }
+
+  /**
+   * Get goal current
+   * @returns {Promise<number>} - Current in mA 
+   */
+  async getGoalCurrent() {
+    return await this.readWord(CONTROL_TABLE.GOAL_CURRENT);
+  }
+
+  /**
    * Get present voltage
    * @returns {Promise<number>} - Voltage in 0.1V units
    */
@@ -361,9 +378,8 @@ export class DynamixelDevice extends EventEmitter {
       320: 'XL-320',
       1020: 'XL430-W250',
       1060: 'XL330-M077',
-      1070: 'XC430-W150', // Corrected model number
       1190: 'XL330-M288',
-      1200: 'XL330-M288-T', // Your actual motor
+      1200: 'XC430-W150',
       1210: 'XC430-W240',
       1270: 'XC330-T181',
       1280: 'XC330-T288',

--- a/src/dynamixel/constants.js
+++ b/src/dynamixel/constants.js
@@ -36,19 +36,7 @@ export const ERROR_FLAGS = {
   ACCESS_ERROR: 0x07
 };
 
-// Model Numbers - Quick lookup for model identification
-export const MODEL_NUMBERS = {
-  XL330_M288_T: 1200,
-  XC430_W150: 1070,
-  XC330_M288: 1300,
-  XC330_M181: 1290,
-  XC330_T288: 1280,
-  XC330_T181: 1270
-};
-
 // Common Control Table Addresses (varies by model)
-// For detailed control table information including size, access, ranges, etc.
-// use MotorProfiles.getProfile(modelName).controlTable
 export const CONTROL_TABLE = {
   MODEL_NUMBER: 0,
   MODEL_INFORMATION: 2,
@@ -66,15 +54,12 @@ export const CONTROL_TABLE = {
   MAX_VOLTAGE_LIMIT: 32,
   MIN_VOLTAGE_LIMIT: 34,
   PWM_LIMIT: 36,
-  CURRENT_LIMIT: 38,
   VELOCITY_LIMIT: 44,
   MAX_POSITION_LIMIT: 48,
   MIN_POSITION_LIMIT: 52,
   EXTERNAL_PORT_MODE_1: 56,
   EXTERNAL_PORT_MODE_2: 57,
   EXTERNAL_PORT_MODE_3: 58,
-  STARTUP_CONFIGURATION: 60,
-  PWM_SLOPE: 62,
   SHUTDOWN: 63,
   TORQUE_ENABLE: 64,
   LED: 65,
@@ -99,14 +84,13 @@ export const CONTROL_TABLE = {
   MOVING: 122,
   MOVING_STATUS: 123,
   PRESENT_PWM: 124,
-  PRESENT_CURRENT: 126,
+  PRESENT_LOAD: 126,
   PRESENT_VELOCITY: 128,
   PRESENT_POSITION: 132,
   VELOCITY_TRAJECTORY: 136,
   POSITION_TRAJECTORY: 140,
   PRESENT_INPUT_VOLTAGE: 144,
-  PRESENT_TEMPERATURE: 146,
-  BACKUP_READY: 147
+  PRESENT_TEMPERATURE: 146
 };
 
 // U2D2 USB Device Information

--- a/tests/unit/DynamixelDevice.test.js
+++ b/tests/unit/DynamixelDevice.test.js
@@ -251,6 +251,28 @@ describe('DynamixelDevice', () => {
     });
   });
 
+  describe('Current Control', () => {
+    test('should set goal current', async() => {
+      mockConnection.sendAndWaitForResponse.mockResolvedValue(
+        createStatusPacketBuffer(1, 0, [])
+      );
+
+      await device.setGoalCurrent(500);
+
+      expect(mockConnection.sendAndWaitForResponse).toHaveBeenCalled();
+    });
+
+    test('should get goal current', async() => {
+      mockConnection.sendAndWaitForResponse.mockResolvedValue(
+        createStatusPacketBuffer(1, 0, [0xF4, 0x01]) // 500 in little-endian
+      );
+
+      const current = await device.getGoalCurrent();
+
+      expect(current).toBe(500);
+    });
+  });
+
   describe('Status Reading', () => {
     test('should read temperature', async() => {
       mockConnection.sendAndWaitForResponse.mockResolvedValue(


### PR DESCRIPTION
L284-L300 on `src/dynamixel/DynamixelDevice.js`  are the main addition (to work with my changes on dynaforge).

`src/dynamixel/constants.js` was just missing `GOAL_CURRENT` which I fixed, but it looks like upstream changes already fixed that and added more functionality here.